### PR TITLE
Specify Ruby version for scripts using Ruby 1.8

### DIFF
--- a/Commands/Add Theme Support.tmCommand
+++ b/Commands/Add Theme Support.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 
 path = ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 require path

--- a/Commands/Admin Menu Page___.tmCommand
+++ b/Commands/Admin Menu Page___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 
 WordPress.admin_menu()</string>

--- a/Commands/Admin Submenu Page___.tmCommand
+++ b/Commands/Admin Submenu Page___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 
 WordPress.add_submenu()</string>

--- a/Commands/Cache.tmCommand
+++ b/Commands/Cache.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Completions for Carrington___.tmCommand
+++ b/Commands/Completions for Carrington___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Completions for Word___.tmCommand
+++ b/Commands/Completions for Word___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/current_word'

--- a/Commands/Constant___.tmCommand
+++ b/Commands/Constant___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Definition for Word___.tmCommand
+++ b/Commands/Definition for Word___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 WordPress.function_define()</string>
 	<key>fallbackInput</key>

--- a/Commands/Go to function___.tmCommand
+++ b/Commands/Go to function___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 WordPress.goto_function()</string>
 	<key>input</key>

--- a/Commands/Internationalize.tmCommand
+++ b/Commands/Internationalize.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 path = ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 require path
 

--- a/Commands/Post Thumbnail.tmCommand
+++ b/Commands/Post Thumbnail.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Preferences.tmCommand
+++ b/Commands/Preferences.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/detach"
 require "#{ENV['TM_BUNDLE_SUPPORT']}/preferences.rb"
 TextMate.detach { 

--- a/Commands/Remove Theme Support.tmCommand
+++ b/Commands/Remove Theme Support.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 
 path = ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 require path

--- a/Commands/Taxonomy.tmCommand
+++ b/Commands/Taxonomy.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Validate Plugin ReadMe.tmCommand
+++ b/Commands/Validate Plugin ReadMe.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require "#{ENV['TM_BUNDLE_SUPPORT']}/validator.rb"
 WPValidator.validate_readme
 </string>

--- a/Commands/add___.tmCommand
+++ b/Commands/add___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/add_action___.tmCommand
+++ b/Commands/add_action___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes' 

--- a/Commands/add_filter___.tmCommand
+++ b/Commands/add_filter___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/attr____.tmCommand
+++ b/Commands/attr____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/bloginfo.tmCommand
+++ b/Commands/bloginfo.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 
 bloginfo_get = false
 

--- a/Commands/enqueue.tmCommand
+++ b/Commands/enqueue.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/get____.tmCommand
+++ b/Commands/get____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/get_bloginfo.tmCommand
+++ b/Commands/get_bloginfo.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 
 bloginfo_get = true
 

--- a/Commands/get_posts___.tmCommand
+++ b/Commands/get_posts___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'
 
 ret = "\\$${1:posts} = get_posts(${2:array($0)});"

--- a/Commands/is____.tmCommand
+++ b/Commands/is____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/metadata.tmCommand
+++ b/Commands/metadata.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/post_var___.tmCommand
+++ b/Commands/post_var___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 WordPress.post_var()</string>
 	<key>input</key>

--- a/Commands/query_var.tmCommand
+++ b/Commands/query_var.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 WordPress.query_var()</string>
 	<key>input</key>

--- a/Commands/register script.tmCommand
+++ b/Commands/register script.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'
 

--- a/Commands/register style.tmCommand
+++ b/Commands/register style.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'
 

--- a/Commands/the____.tmCommand
+++ b/Commands/the____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/transients___.tmCommand
+++ b/Commands/transients___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/user_can___.tmCommand
+++ b/Commands/user_can___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/wp____.tmCommand
+++ b/Commands/wp____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/wp_query___ 2.tmCommand
+++ b/Commands/wp_query___ 2.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/wp_query___.tmCommand
+++ b/Commands/wp_query___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'
 
 ret = "\\$${1:query} = New WP_Query(${2:array(${0})});"

--- a/Commands/wp_remote____.tmCommand
+++ b/Commands/wp_remote____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/wpdb___.tmCommand
+++ b/Commands/wpdb___.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_BUNDLE_SUPPORT'] + '/common.rb'
 WordPress.wpdb()</string>
 	<key>input</key>

--- a/Commands/wpmu____.tmCommand
+++ b/Commands/wpmu____.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby18 -wKU
 require ENV['TM_SUPPORT_PATH'] + '/lib/osx/plist'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'


### PR DESCRIPTION
# Summary

This pull request makes the bundle compatible with Texmate 2 running on newer versions of macOS, where the default Ruby version is 2.x, i.e. every version starting from Mavericks.

# Details

Commands used by the bundle rely on Ruby 1.8.x. This Ruby version is not bundled with newer versions of macOS. Texmate 2 provides this older Ruby version for compatibility with older bundles. However, the bundles may need to opt in by specifying `ruby18` in the shebang line.

This bundle was showing the error:

`ruby: warning: -K is specified; it is for 1.8 compatibility and may cause odd behavior`.

This pull requests enforces the use of Ruby 1.8 and makes all commands work again.

